### PR TITLE
fix: types

### DIFF
--- a/src/data-collection/link-pulls.test.ts
+++ b/src/data-collection/link-pulls.test.ts
@@ -6,8 +6,6 @@ import ISSUE_CROSS_REPO_LINK from "./fixtures/issue-89.json"; // pr188 is linked
 import ISSUE_SAME_REPO_LINK from "./fixtures/issue-90.json"; // pr91 is linked to this issue
 import ISSUE_NO_LINK from "./fixtures/issue-92.json"; // no link
 
-import pr23 from "./fixtures/pr-23.json";
-
 import PR_CROSS_REPO_LINK from "./fixtures/pr-188.json";
 import PR_SAME_REPO_LINK from "./fixtures/pr-91.json";
 
@@ -28,62 +26,70 @@ process.argv = ["path/to/node", "path/to/script", `--auth=${GITHUB_TOKEN}`];
 describe("mock scenarios", () => {
   it("should return null if there is no link event on the issue", async () => {
     const result = await linkPulls(PARAMS_ISSUE_NO_LINK);
-    expect(result).toBeNull();
+    expect(result).toEqual([]);
   });
 
-  it("should find the linked PULL REQUEST, starting from the ISSUE, in the SAME REPOSITORY", async () => {
+  it("should find the merged, linked PULL REQUESTS, starting from the ISSUE, in the SAME REPOSITORY", async () => {
     const result = await linkPulls(PARAMS_ISSUE_SAME_REPO_LINK);
-    const expected = { issue: { html_url: PR_SAME_REPO_LINK.html_url } };
-    expect(result).toMatchObject(expected);
+    const expectedUrl = PR_SAME_REPO_LINK.html_url;
+    const matchingLinks = result.filter((link) => link.source.issue.html_url === expectedUrl);
+    expect(matchingLinks.length).toBe(1);
   });
 
-  it("should find the linked PULL REQUEST, starting from the ISSUE, across ANY REPOSITORY (within the organization)", async () => {
+  it("should find the merged, linked PULL REQUESTS, starting from the ISSUE, across ANY REPOSITORY (within the organization)", async () => {
     const result = await linkPulls(PARAMS_ISSUE_CROSS_REPO_LINK);
-    const expected = { issue: { html_url: PR_CROSS_REPO_LINK.html_url } };
-    expect(result).toMatchObject(expected);
+    const expectedUrl = PR_CROSS_REPO_LINK.html_url;
+    const matchingLinks = result.filter((link) => link.source.issue.html_url === expectedUrl);
+    expect(matchingLinks.length).toBe(1);
   });
 });
 
 describe("real scenarios", () => {
-  it("ubiquibot/comment-incentives/issues/22: should find the linked PULL REQUEST, starting from the ISSUE, in the SAME REPOSITORY", async () => {
+  it("ubiquibot/comment-incentives/issues/22: should find the merged, linked PULL REQUESTS, starting from the ISSUE, in the SAME REPOSITORY", async () => {
     const result = await linkPulls(parseGitHubUrl("https://github.com/ubiquibot/comment-incentives/issues/22"));
-    const expected = { issue: { html_url: expect.stringMatching(/\/pull\/\d+$/) } };
-    expect(result).toMatchObject(expected);
+    const expectedUrl = "https://github.com/ubiquibot/comment-incentives/pull/25";
+    result.forEach((res) => expect(res.source.issue.html_url).toMatch(/\/pull\/\d+$/));
+    const matchingLinks = result.filter((res) => res.source.issue.html_url === expectedUrl);
+    expect(matchingLinks.length).toBeGreaterThan(0);
   });
 
-  it("ubiquibot/comment-incentives/issues/3: should find the linked PULL REQUEST, starting from the ISSUE, in the SAME REPOSITORY", async () => {
+  it("ubiquibot/comment-incentives/issues/3: should find the merged, linked PULL REQUESTS, starting from the ISSUE, in the SAME REPOSITORY", async () => {
     const result = await linkPulls(parseGitHubUrl("https://github.com/ubiquibot/comment-incentives/issues/3"));
-    const expected = { issue: { html_url: expect.stringMatching(/\/pull\/\d+$/) } };
-    expect(result).toMatchObject(expected);
+    const expectedUrl = "https://github.com/ubiquibot/comment-incentives/pull/4";
+    result.forEach((res) => expect(res.source.issue.html_url).toMatch(/\/pull\/\d+$/));
+    const matchingLinks = result.filter((res) => res.source.issue.html_url === expectedUrl);
+    expect(matchingLinks.length).toBeGreaterThan(0);
   });
 
-  it("ubiquibot/comment-incentives/issues/15: should find the linked PULL REQUEST, starting from the ISSUE, in the SAME REPOSITORY", async () => {
+  it("ubiquibot/comment-incentives/issues/15: should find the merged, linked PULL REQUESTS, starting from the ISSUE, in the SAME REPOSITORY", async () => {
     const result = await linkPulls(parseGitHubUrl("https://github.com/ubiquibot/comment-incentives/issues/15"));
-    const expected = { issue: { html_url: expect.stringMatching(/\/pull\/\d+$/) } };
-    expect(result).toMatchObject(expected);
+    const expectedUrl = "https://github.com/ubiquibot/comment-incentives/pull/16";
+    result.forEach((res) => expect(res.source.issue.html_url).toMatch(/\/pull\/\d+$/));
+    const matchingLinks = result.filter((res) => res.source.issue.html_url === expectedUrl);
+    expect(matchingLinks.length).toBeGreaterThan(0);
   });
 
-  it("ubiquibot/comment-incentives/issues/19: should find the linked PULL REQUEST, starting from the ISSUE, in the SAME REPOSITORY", async () => {
+  it("ubiquibot/comment-incentives/issues/19: should find the merged, linked PULL REQUESTS, starting from the ISSUE, in the SAME REPOSITORY", async () => {
     const result = await linkPulls(parseGitHubUrl("https://github.com/ubiquibot/comment-incentives/issues/19"));
-
-    // console.dir(result, { depth: null });
-
-    const expected = { issue: { html_url: pr23.html_url } };
-    expect(result).toMatchObject(expected);
+    const expectedUrls = ["https://github.com/ubiquibot/comment-incentives/pull/21", "https://github.com/ubiquibot/comment-incentives/pull/23"];
+    expectedUrls.forEach((url) => {
+      const matchingLinks = result.filter((res) => res.source.issue.html_url === url);
+      expect(matchingLinks.length).toBeGreaterThan(0);
+    });
   });
-
-  // @DEV: no need to over-engineer. We only need to link the pull request from the issue, not the other way around.
-
-  // it("should find the linked ISSUE, starting from the PULL REQUEST, in the SAME REPOSITORY", async () => {
-  //   const result = await linkPulls(PARAMS_PR_SAME_REPO_LINK);
-
-  //   const expected = { issue: { node_id: ISSUE_SAME_REPO_LINK.node_id } };
-  //   expect(result).toMatchObject(expected);
-  // });
-
-  // it("should find the linked ISSUE, starting from the PULL REQUEST, across ANY REPOSITORY (within the organization)", async () => {
-  //   const result = await linkPulls(PARAMS_PR_CROSS_REPO_LINK);
-  //   const expected = { issue: { node_id: ISSUE_CROSS_REPO_LINK.node_id } };
-  //   expect(result).toMatchObject(expected);
-  // });
 });
+
+// @DEV: no need to over-engineer. We only need to link the pull request from the issue, not the other way around.
+
+// it("should find the linked ISSUE, starting from the PULL REQUEST, in the SAME REPOSITORY", async () => {
+//   const result = await linkPulls(PARAMS_PR_SAME_REPO_LINK);
+
+//   const expected = [{ issue: { node_id: ISSUE_SAME_REPO_LINK.node_id } }];
+//   expect(result).toMatchObject(expected);
+// });
+
+// it("should find the linked ISSUE, starting from the PULL REQUEST, across ANY REPOSITORY (within the organization)", async () => {
+//   const result = await linkPulls(PARAMS_PR_CROSS_REPO_LINK);
+//   const expected = [{ issue: { node_id: ISSUE_CROSS_REPO_LINK.node_id } }];
+//   expect(result).toMatchObject(expected);
+// });

--- a/src/github-types.ts
+++ b/src/github-types.ts
@@ -6,7 +6,21 @@ export type GitHubComment = RestEndpointMethodTypes["issues"]["listComments"]["r
 export type GitHubLabel = RestEndpointMethodTypes["issues"]["listLabelsOnIssue"]["response"]["data"][0];
 export type GitHubIssueEvent = RestEndpointMethodTypes["issues"]["listEvents"]["response"]["data"][0];
 export type GitHubTimelineEvent = RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["response"]["data"][0];
+
+type LinkPullRequestDetail = {
+  url: "https://api.github.com/repos/ubiquibot/comment-incentives/pulls/25";
+  html_url: "https://github.com/ubiquibot/comment-incentives/pull/25";
+  diff_url: "https://github.com/ubiquibot/comment-incentives/pull/25.diff";
+  patch_url: "https://github.com/ubiquibot/comment-incentives/pull/25.patch";
+  merged_at: "2024-02-16T19:22:01Z";
+};
+
+type SourceIssueWithPullRequest = GitHubIssue | (GitHubPullRequest & { pull_request: LinkPullRequestDetail });
+
 export type GitHubLinkEvent = RestEndpointMethodTypes["issues"]["listEventsForTimeline"]["response"]["data"][0] & {
   event: "connected" | "disconnected" | "cross-referenced";
-  source: GitHubIssue | GitHubPullRequest;
+  source: { issue: SourceIssueWithPullRequest };
 };
+export function isGitHubLinkEvent(event: GitHubTimelineEvent): event is GitHubLinkEvent {
+  return "source" in event;
+}


### PR DESCRIPTION
A bit iffy but this changes the API to return every merged pull request thats associated with the issue, instead of just the latest. 

I assume that this should be fine if the permit is regenerated, and if theres a couple of back-to-back pulls. 